### PR TITLE
fixed grafana errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ./data/grafana:/var/lib/grafana
     ports:
       - "3000:3000"
+    user: "root"
     links:
       - influxdb
     environment:

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,9 @@
 FROM grafana/grafana:latest
 
+USER root
+RUN apt-get update && \
+    apt-get -y install procps
+USER solr 
+
 COPY ./grafana-run.sh /
 ENTRYPOINT ["/grafana-run.sh"]


### PR DESCRIPTION
Fixed error:
1. t=2018-05-05T09:19:04+0000 lvl=info msg="Request Completed" logger=context userId=1 orgId=1 uname=admin method=POST path=/api/datasources status=409 remote_addr=127.0.0.1 time_ms=62 size=55 referer= /grafana-run.sh: line 21: pkill: command not found

2. mkdir: cannot create directory '/var/lib/grafana/plugins': Permission denied

Fixes #1 